### PR TITLE
Change unzip dependency to unzip2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Zip and unzip files or directories in Node.js.
 ## Installation &nbsp; [![NPM version](https://badge.fury.io/js/machinepack-zip.svg)](http://badge.fury.io/js/machinepack-zip) [![Build Status](https://travis-ci.org/mikermcneil/machinepack-zip.png?branch=master)](https://travis-ci.org/mikermcneil/machinepack-zip)
 
 ```sh
-$ npm install machinepack-zip
+$ npm install machinepack-zip-2
 ```
 
 ## Usage
@@ -27,4 +27,3 @@ Learn more at <a href="http://node-machine.org/implementing/FAQ" title="Machine 
 ## License
 
 MIT &copy; 2015 contributors
-

--- a/machines/unzip.js
+++ b/machines/unzip.js
@@ -30,7 +30,7 @@ module.exports = {
 
     var path = require('path');
     var fs = require('fs');
-    var unzip = require('unzip');
+    var unzip = require('unzip2');
     var Filesystem = require('machinepack-fs');
 
     var sourceArchive = path.resolve(inputs.source);

--- a/machines/zip.js
+++ b/machines/zip.js
@@ -33,11 +33,11 @@ module.exports = {
 
     var path = require('path');
     var fs = require('fs');
-    var _ = require('lodash');
+    var _map = require('lodash.map');
     var Archiver = require('archiver');
     var Filesystem = require('machinepack-fs');
 
-    var srcPaths = _.map(inputs.sources, function (sourcePath){
+    var srcPaths = _map(inputs.sources, function (sourcePath){
       return path.resolve(sourcePath);
     });
     var zipFileDestination = path.resolve(inputs.destination);
@@ -71,7 +71,7 @@ module.exports = {
 
         archive.pipe(outputStream);
 
-        archive.bulk(_.map(srcPaths, function convertPathIntoArchiverBulkInstr(srcPath){
+        archive.bulk(_map(srcPaths, function convertPathIntoArchiverBulkInstr(srcPath){
           // Get (1) srcPath's parent and (2) the relative path to our srcPath from its parent
           var srcParent = path.resolve(srcPath, '..');
           var srcRelative = path.relative(srcParent, srcPath);

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-  "name": "machinepack-zip",
-  "version": "1.2.0",
+  "name": "machinepack-zip-2",
+  "version": "2.0.0",
   "description": "Zip and unzip files or directories in Node.js.",
   "scripts": {
     "test": "node ./node_modules/test-machinepack-mocha/bin/testmachinepack-mocha.js"
   },
   "keywords": [
     "Zip",
+    "Zip-2",
     "machines",
     "machinepack"
   ],
-  "author": "",
+  "author": "@josebaseba",
   "license": "MIT",
   "dependencies": {
     "archiver": "^0.14.2",
-    "lodash": "^3.2.0",
+    "lodash.map": "^4.6.0",
     "machine": "^10.3.1",
     "machinepack-fs": "^2.1.0",
     "unzip2": "^0.2.5"
@@ -23,7 +24,7 @@
     "test-machinepack-mocha": "^2.1.1"
   },
   "machinepack": {
-    "friendlyName": "Zip",
+    "friendlyName": "Zip-2",
     "machineDir": "machines/",
     "machines": [
       "unzip",
@@ -33,6 +34,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:mikermcneil/machinepack-zip.git"
+    "url": "git@github.com:josebaseba/machinepack-zip-2.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machinepack-zip",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Zip and unzip files or directories in Node.js.",
   "scripts": {
     "test": "node ./node_modules/test-machinepack-mocha/bin/testmachinepack-mocha.js"
@@ -17,7 +17,7 @@
     "lodash": "^3.2.0",
     "machine": "^10.3.1",
     "machinepack-fs": "^2.1.0",
-    "unzip": "^0.1.11"
+    "unzip2": "^0.2.5"
   },
   "devDependencies": {
     "test-machinepack-mocha": "^2.1.1"


### PR DESCRIPTION
Hey Mike, 

I'm using this machine in one of my projects, the thing is that the unzip package was throwing weird errors:

`Error: invalid signature: 0x5cf80008`

The fix for the bug is implemented in unzip2, which is the same package but updated and with fewer bugs :)

I think that changing the dependency from one to the other would be better.

No API changes.
